### PR TITLE
Use go-loggly from go-slog

### DIFF
--- a/components/class-go-slog.php
+++ b/components/class-go-slog.php
@@ -65,7 +65,7 @@ class GO_Slog
 	}//end config
 
 	/**
-	 * log to SimpleDB
+	 * map go_slog calls to Loggly's 'inputs' API
 	 *
 	 * @param $code string The code you want to log
 	 * @param $message string The message you want to log
@@ -73,17 +73,20 @@ class GO_Slog
 	 */
 	public function log( $code = '', $message = '', $data = '' )
 	{
-		$this->check_domains();
+		$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
 
-		$microtime = explode( ' ', microtime() );
+		$log_item = array(
+			'code'    => $code,
+			'message' => $message,
+			'data'    => serialize( $data ), // we flatten our data here so as to not use up loggly's 150 total parsed json key limit. See https://community.loggly.com/customer/portal/questions/6544954-json-not-getting-parsed
+			'from'    => ( isset( $backtrace[2]['file'], $backtrace[2]['line'] ) ) ? $backtrace[2]['file'] . ':' . $backtrace[2]['line'] : NULL,
+		);
 
-		$log_item['log_date'] = array( 'value' => $microtime[1] . substr( $microtime[0], 1 ) );
-		$log_item['host']     = array( 'value' => parse_url( site_url( '/' ), PHP_URL_HOST ) );
-		$log_item['code']     = array( 'value' => $code );
-		$log_item['message']  = array( 'value' => $message );
-		$log_item['data']     = array( 'value' => serialize( $data ) );
+		$tags = array( 'go-slog' );
+		$tags[] = ( isset( $backtrace[3]['class'] ) ) ? $backtrace[3]['class'] : NULL;
+		$tags[] = ( isset( $backtrace[3]['function'] ) ) ? $backtrace[3]['function'] : NULL;
 
-		$this->simple_db()->putAttributes( $this->config['aws_sdb_domain'] . $this->domain_suffix['curr_week'], uniqid( 'log_item_' ), $log_item );
+		$response = go_loggly()->inputs( $log_item, $tags );
 	} //end log
 
 	/**


### PR DESCRIPTION
- related to https://github.com/GigaOM/legacy-pro/issues/3806, and specifically [this](https://github.com/GigaOM/go-loggly/pull/3#issuecomment-49441761) discussion.
- using `GO_Slog::log()` but replacing it with a `go-loggly` implementation.
